### PR TITLE
Fix/readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,21 +18,21 @@ to start the app in development mode.
 
 ## Implementation
 
-This project uses the `@ts4nfdi/terminology-service-suite` package to display Terminology Service widgets in a Next.js app.
+This demo project uses widgets from the `@ts4nfdi/terminology-service-suite` package.
 
-The package is already installed in this demo project. If you want to use the same widgets in your own project, install the package with:
+The package is already installed in this project. If you want to use the widgets in another React or Next.js project, install the package first:
 
 ```bash
 npm install @ts4nfdi/terminology-service-suite
 ```
 
-Then import the widget you need into your React component and add it to your page.
+After installing the package, choose the widget you want to use, import it into your React component, and render it on your page with the required properties.
 
-You can find the full list of available widgets, their properties, and usage examples in the Storybook documentation:
+The easiest way to find the right widget and understand how to configure it is to use the Storybook documentation. Storybook shows the available widgets, their properties, example configurations, and live previews:
 
-https://ts4nfdi.github.io/terminology-service-suite/comp/latest/
+[Open the Storybook documentation](https://terminology.services.base4nfdi.de/tss/comp/latest/iframe.html?viewMode=docs&id=overview--docs&globals=#how-to-use-this-storybook)
 
-In this demo project, you can see an example implementation in `MainPage.tsx`
+In this demo project, you can see an example implementation in `MainPage.tsx`.
 
 
 ## React Next.js Widgets Demo Project - Docker Usage

--- a/README.md
+++ b/README.md
@@ -5,11 +5,7 @@ For this demo, a Next.js app was set up with `Node.js v18.18.0`.
 
 ## Install and run the demo application
 
-1) Authenticate
-Copy your GitHub PAT into the `.npmrc` file. 
-Click [here](https://ts4nfdi.github.io/terminology-service-suite/comp/latest/) for detailed instructions of the authentication process.
-
-2) Install
+1) Install
 The widgets are developed with React 17. 
 If the consumer app uses React > 17, the `--legacy-peer-deps` flag must be set during installation. 
 We are in the process of testing the widgets with React versions > 17, but there may still be unwanted behavior.
@@ -17,7 +13,7 @@ We are in the process of testing the widgets with React versions > 17, but there
 npm install --legacy-peer-deps
 ```
 
-3) Run
+2) Run
 ```bash
 npm run dev
 ```

--- a/README.md
+++ b/README.md
@@ -6,11 +6,8 @@ For this demo, a Next.js app was set up with `Node.js v18.18.0`.
 ## Install and run the demo application
 
 1) Install
-The widgets are developed with React 17. 
-If the consumer app uses React > 17, the `--legacy-peer-deps` flag must be set during installation. 
-We are in the process of testing the widgets with React versions > 17, but there may still be unwanted behavior.
 ```bash
-npm install --legacy-peer-deps
+npm install
 ```
 
 2) Run
@@ -107,4 +104,3 @@ This ensures changes in your local project reflect inside the container.
 ---
 
 This guide helps you build, run, and manage your Next.js application using Docker. Happy coding! 🚀
-

--- a/README.md
+++ b/README.md
@@ -18,10 +18,21 @@ to start the app in development mode.
 
 ## Implementation
 
-Click [here](https://ts4nfdi.github.io/terminology-service-suite/comp/latest/) for detailed instructions on how to implement the
-package.
+This project uses the `@ts4nfdi/terminology-service-suite` package to display Terminology Service widgets in a Next.js app.
 
-A sample integration is shown in `MainPage.tsx`.
+The package is already installed in this demo project. If you want to use the same widgets in your own project, install the package with:
+
+```bash
+npm install @ts4nfdi/terminology-service-suite
+```
+
+Then import the widget you need into your React component and add it to your page.
+
+You can find the full list of available widgets, their properties, and usage examples in the Storybook documentation:
+
+https://ts4nfdi.github.io/terminology-service-suite/comp/latest/
+
+In this demo project, you can see an example implementation in `MainPage.tsx`
 
 
 ## React Next.js Widgets Demo Project - Docker Usage


### PR DESCRIPTION
## Summary

This PR updates the README documentation to make the installation and implementation instructions clearer and easier to follow.

## Changes

- Removed the outdated authentication step from the installation instructions.
- Removed the outdated React 17 information and the `--legacy-peer-deps` installation command.
- Updated the install command to use the standard `npm install`.
- Added installation guidance for using `@ts4nfdi/terminology-service-suite` in another React or Next.js project.
- Added a direct link to the Storybook documentation so users can find available widgets, props, configuration examples, and live previews.


## Related Issue:

https://github.com/ts4nfdi/react-widgets-demo-project/issues/4